### PR TITLE
Size optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,33 +3,10 @@ CFLAGS = -std=c99 -Wall -W -Os -ffunction-sections -fdata-sections -fomit-frame-
 
 all: bin/totp.89z
 
-bin/totp.89z: bin/sha1.o bin/hmac.o bin/hotp.o bin/time.o bin/tile.o bin/secret_file.o bin/secret_util.o bin/secret_manifest.o bin/new_secret.o bin/time_zone.o bin/main_menu.o totp.c
+bin/totp.89z: codes/hash/sha1/sha1/sha1.c codes/hmac/hmac.c codes/hotp/hotp.c time/time.c gfx/tile.c save/secret_file.c save/util.c save/manifest.c dialog/new_secret.c dialog/time_zone.c mainmenu/main_menu.c totp.c
 	chmod 700 commit_hash.sh
 	./commit_hash.sh
-	$(CC) $(CFLAGS) -v --optimize-code --cut-ranges --reorder-sections --remove-unused --merge-constants bin/sha1.o bin/hmac.o bin/hotp.o bin/time.o bin/tile.o bin/secret_file.o bin/secret_util.o bin/secret_manifest.o bin/new_secret.o bin/time_zone.o bin/main_menu.o totp.c -o bin/totp.89z
-
-bin/time.o: time/time.c
-	$(CC) $(CFLAGS) -c time/time.c -o bin/time.o
-bin/hotp.o: codes/hotp/hotp.c
-	$(CC) $(CFLAGS) -c codes/hotp/hotp.c -o bin/hotp.o
-bin/sha1.o: codes/hash/sha1/sha1/sha1.c
-	$(CC) $(CFLAGS) -c codes/hash/sha1/sha1/sha1.c -o bin/sha1.o
-bin/hmac.o: codes/hmac/hmac.c
-	$(CC) $(CFLAGS) -c codes/hmac/hmac.c -o bin/hmac.o
-bin/tile.o: gfx/tile.c
-	$(CC) $(CFLAGS) -c gfx/tile.c -o bin/tile.o
-bin/secret_file.o: save/secret_file.c
-	$(CC) $(CFLAGS) -c save/secret_file.c -o bin/secret_file.o
-bin/secret_util.o: save/util.c
-	$(CC) $(CFLAGS) -c save/util.c -o bin/secret_util.o
-bin/secret_manifest.o: save/manifest.c
-	$(CC) $(CFLAGS) -c save/manifest.c -o bin/secret_manifest.o
-bin/new_secret.o: dialog/new_secret.c
-	$(CC) $(CFLAGS) -c dialog/new_secret.c -o bin/new_secret.o
-bin/time_zone.o: dialog/time_zone.c
-	$(CC) $(CFLAGS) -c dialog/time_zone.c -o bin/time_zone.o
-bin/main_menu.o: mainmenu/main_menu.c
-	$(CC) $(CFLAGS) -c mainmenu/main_menu.c -o bin/main_menu.o
+	$(CC) $(CFLAGS) -v --optimize-code --cut-ranges --reorder-sections --remove-unused --merge-constants totp.c -o bin/totp.89z
 
 clean:
 	rm -rf bin

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,35 @@
 CC = tigcc
-CFLAGS = -std=c89 -c -Wall -Os
+CFLAGS = -std=c99 -Wall -W -Os -ffunction-sections -fdata-sections -fomit-frame-pointer -Wa,--all-relocs,-l -mregparm=5 -mno-bss -DMIN_AMS=207 -DUSE_FLINE_ROM_CALLS -save-temps
 
 all: bin/totp.89z
 
 bin/totp.89z: bin/sha1.o bin/hmac.o bin/hotp.o bin/time.o bin/tile.o bin/secret_file.o bin/secret_util.o bin/secret_manifest.o bin/new_secret.o bin/time_zone.o bin/main_menu.o totp.c
 	chmod 700 commit_hash.sh
 	./commit_hash.sh
-	$(CC) -Wall -Os bin/sha1.o bin/hmac.o bin/hotp.o bin/time.o bin/tile.o bin/secret_file.o bin/secret_util.o bin/secret_manifest.o bin/new_secret.o bin/time_zone.o bin/main_menu.o totp.c -o bin/totp.89z
+	$(CC) $(CFLAGS) -v --optimize-code --cut-ranges --reorder-sections --remove-unused --merge-constants bin/sha1.o bin/hmac.o bin/hotp.o bin/time.o bin/tile.o bin/secret_file.o bin/secret_util.o bin/secret_manifest.o bin/new_secret.o bin/time_zone.o bin/main_menu.o totp.c -o bin/totp.89z
 
 bin/time.o: time/time.c
-	$(CC) $(CFLAGS) time/time.c -o bin/time.o
+	$(CC) $(CFLAGS) -c time/time.c -o bin/time.o
 bin/hotp.o: codes/hotp/hotp.c
-	$(CC) $(CFLAGS) codes/hotp/hotp.c -o bin/hotp.o
+	$(CC) $(CFLAGS) -c codes/hotp/hotp.c -o bin/hotp.o
 bin/sha1.o: codes/hash/sha1/sha1/sha1.c
-	$(CC) $(CFLAGS) codes/hash/sha1/sha1/sha1.c -o bin/sha1.o
+	$(CC) $(CFLAGS) -c codes/hash/sha1/sha1/sha1.c -o bin/sha1.o
 bin/hmac.o: codes/hmac/hmac.c
-	$(CC) $(CFLAGS) codes/hmac/hmac.c -o bin/hmac.o
+	$(CC) $(CFLAGS) -c codes/hmac/hmac.c -o bin/hmac.o
 bin/tile.o: gfx/tile.c
-	$(CC) $(CFLAGS) gfx/tile.c -o bin/tile.o
+	$(CC) $(CFLAGS) -c gfx/tile.c -o bin/tile.o
 bin/secret_file.o: save/secret_file.c
-	$(CC) $(CFLAGS) save/secret_file.c -o bin/secret_file.o
+	$(CC) $(CFLAGS) -c save/secret_file.c -o bin/secret_file.o
 bin/secret_util.o: save/util.c
-	$(CC) $(CFLAGS) save/util.c -o bin/secret_util.o
+	$(CC) $(CFLAGS) -c save/util.c -o bin/secret_util.o
 bin/secret_manifest.o: save/manifest.c
-	$(CC) $(CFLAGS) save/manifest.c -o bin/secret_manifest.o
+	$(CC) $(CFLAGS) -c save/manifest.c -o bin/secret_manifest.o
 bin/new_secret.o: dialog/new_secret.c
-	$(CC) $(CFLAGS) dialog/new_secret.c -o bin/new_secret.o
+	$(CC) $(CFLAGS) -c dialog/new_secret.c -o bin/new_secret.o
 bin/time_zone.o: dialog/time_zone.c
-	$(CC) $(CFLAGS) dialog/time_zone.c -o bin/time_zone.o
+	$(CC) $(CFLAGS) -c dialog/time_zone.c -o bin/time_zone.o
 bin/main_menu.o: mainmenu/main_menu.c
-	$(CC) $(CFLAGS) mainmenu/main_menu.c -o bin/main_menu.o
+	$(CC) $(CFLAGS) -c mainmenu/main_menu.c -o bin/main_menu.o
 
 clean:
 	rm -rf bin

--- a/codes/hash/sha1/sha1/sha1.c
+++ b/codes/hash/sha1/sha1/sha1.c
@@ -44,7 +44,7 @@ A million repetitions of "a"
 
 /* Hash a single 512-bit block. This is the core of the algorithm. */
 
-void SHA1Transform(
+static void SHA1Transform(
     uint32_t state[5],
     const unsigned char buffer[64]
 )
@@ -172,7 +172,7 @@ void SHA1Transform(
 
 /* SHA1Init - Initialize new context */
 
-void SHA1Init(
+static void SHA1Init(
     SHA1_CTX * context
 )
 {
@@ -188,7 +188,7 @@ void SHA1Init(
 
 /* Run your data through this. */
 
-void SHA1Update(
+static void SHA1Update(
     SHA1_CTX * context,
     const unsigned char *data,
     uint32_t len
@@ -221,7 +221,7 @@ void SHA1Update(
 
 /* Add padding and return the message digest. */
 
-void SHA1Final(
+static void SHA1Final(
     unsigned char digest[20],
     SHA1_CTX * context
 )
@@ -272,7 +272,7 @@ void SHA1Final(
     memset(&finalcount, '\0', sizeof(finalcount));
 }
 
-void SHA1(
+static void SHA1(
     char *hash_out,
     const char *str,
     int len)

--- a/codes/hash/sha1/sha1/sha1.h
+++ b/codes/hash/sha1/sha1/sha1.h
@@ -16,29 +16,4 @@ typedef struct
     unsigned char buffer[64];
 } SHA1_CTX;
 
-void SHA1Transform(
-    uint32_t state[5],
-    const unsigned char buffer[64]
-    );
-
-void SHA1Init(
-    SHA1_CTX * context
-    );
-
-void SHA1Update(
-    SHA1_CTX * context,
-    const unsigned char *data,
-    uint32_t len
-    );
-
-void SHA1Final(
-    unsigned char digest[20],
-    SHA1_CTX * context
-    );
-
-void SHA1(
-    char *hash_out,
-    const char *str,
-    int len);
-
 #endif /* SHA1_H */

--- a/codes/hmac/hmac.c
+++ b/codes/hmac/hmac.c
@@ -7,14 +7,24 @@
 #define HMAC_IPAD 0x36
 #define HMAC_OPAD 0x5c
 
-void hmac (
-	unsigned char *dst,	
+/* HMAC as defined in RFC 2104 */
+static void hmac (
+	/* 
+	 * pointer to output result
+	 * assumed to be large enough for hash output
+	 */
+	unsigned char *dst,
+	/* pointer to secret key, must be key_length bytes long */
 	unsigned char *key,
+	/* length of secret key. not longer than 64 bytes.
+	 * if you have a longer key, then apply the hash function 
+	 * to it before passing it into this function */
 	unsigned int key_len,
+	/* message to compute HMAC over */
 	unsigned char *data,
+	/* length of message to compute HMAC over */
 	unsigned int data_len
-)
-{
+) {
 	unsigned int i;
 	unsigned char k_inner [64];
 	unsigned char k_outer [64];

--- a/codes/hmac/hmac.h
+++ b/codes/hmac/hmac.h
@@ -6,23 +6,4 @@
 
 #define ALG_SHA1 0
 
-/* HMAC as defined in RFC 2104 */
-void hmac (
-	/* 
-	 * pointer to output result
-	 * assumed to be large enough for hash output
-	 */
-	unsigned char *dst,
-	/* pointer to secret key, must be key_length bytes long */
-	unsigned char *key,
-	/* length of secret key. not longer than 64 bytes.
-	 * if you have a longer key, then apply the hash function 
-	 * to it before passing it into this function */
-	unsigned int key_len,
-	/* message to compute HMAC over */
-	unsigned char *data,
-	/* length of message to compute HMAC over */
-	unsigned int data_len
-);
-
 #endif

--- a/codes/hotp/hotp.c
+++ b/codes/hotp/hotp.c
@@ -3,7 +3,19 @@
 #include "hotp.h"
 #include "../hmac/hmac.h"
 
-void hotp (char *dst, unsigned char *key, unsigned int key_len, int64_t counter, unsigned int code_len) {
+/* HOTP as defined in RFC 4226 */
+static void hotp (
+	/* output of hotp. null terminated string with code.
+	 * allocated length must be code_len + 1 */
+    char *dst,
+	/* secret key */
+	unsigned char *key,
+	unsigned int key_len,
+	/* counter */
+	int64_t counter,
+	/* number of decimal digits for the code */
+	unsigned int code_len
+) {
 	/* Do Hmac with specified hash function */
 	unsigned char hmac_output [20];
 	hmac (hmac_output, key, key_len, (unsigned char *) &counter, 8);

--- a/codes/hotp/hotp.h
+++ b/codes/hotp/hotp.h
@@ -5,18 +5,4 @@
 
 #include "../hash/algo.h"
 
-/* HOTP as defined in RFC 4226 */
-void hotp (
-	/* output of hotp. null terminated string with code.
-	 * allocated length must be code_len + 1 */
-    char *dst,
-	/* secret key */
-	unsigned char *key,
-	unsigned int key_len,
-	/* counter */
-	int64_t counter,
-	/* number of decimal digits for the code */
-	unsigned int code_len
-);
-
 #endif

--- a/dialog/new_secret.c
+++ b/dialog/new_secret.c
@@ -33,7 +33,7 @@ const unsigned char conversion_table [] = {
  * or 0 if unsuccessful
  * Adapted from a similar function in CyoEncode Library
  */
-unsigned short base_32 (unsigned char *dst, char *src) {
+static unsigned short base_32 (unsigned char *dst, char *src) {
 	unsigned short i, ii = 0;
 	unsigned char *tmp_dst = dst;
 	char tmp [8];
@@ -142,7 +142,8 @@ char ERROR_TITLE [] = "Failed to save new secret.";
 char ERROR_MEM [] = "You may not have enough memory.";
 char ERROR_UNKNOWN [] = "An unknown error occured.";
 
-int run_new_secret_dialog (HANDLE manifest_handle, int wide_format) {
+/* sets up the dialog handle */
+static int run_new_secret_dialog (HANDLE manifest_handle, int wide_format) {
 	char request_buf [120];
 	char *secret = &request_buf [0];
 	char *label = &request_buf [68];
@@ -274,7 +275,7 @@ DIALOG dialog_open_file = {
 
 const char OPEN_SECRET_TEXT_BUF [] = "Open Secret\0File Name";
 
-int run_open_secret_dialog (HANDLE manifest_handle, int wide_format) {
+static int run_open_secret_dialog (HANDLE manifest_handle, int wide_format) {
 	char *invalid_input_msg = NULL;
 	char request_buf [9];
 	dialog_open_file.TextOffset = (void *) OPEN_SECRET_TEXT_BUF - (void *) &dialog_open_file;

--- a/dialog/new_secret.h
+++ b/dialog/new_secret.h
@@ -8,7 +8,4 @@
 #define ND_MEM 2
 #define ND_ERROR 3
 
-/* sets up the dialog handle */
-int run_new_secret_dialog (HANDLE manifest_handle, int wide_format);
-int run_open_secret_dialog (HANDLE manifest_handle, int wide_format);
 #endif

--- a/dialog/time_zone.c
+++ b/dialog/time_zone.c
@@ -46,7 +46,8 @@ DIALOG dialog_time_zone = {
 
 const char TIME_ZONE_BUF [] = "Enter the UTC offset for your time zone\0If negative, enter the\0minus sign in the hours field.\0Hours\0Minutes";
 
-int run_time_zone_dialog (HANDLE manifest_handle, int wide_format) {
+/* dialog for setting the time zone */
+static int run_time_zone_dialog (HANDLE manifest_handle, int wide_format) {
 	char *invalid_input_reason = NULL;
 	short tz;
 	char request_buffer [16];

--- a/dialog/time_zone.h
+++ b/dialog/time_zone.h
@@ -7,6 +7,4 @@
 #define TZ_MEM 2
 #define TZ_ERROR 3
 
-/* dialog for setting the time zone */
-int run_time_zone_dialog (HANDLE manifest_handle, int wide_format);
 #endif

--- a/gfx/tile.c
+++ b/gfx/tile.c
@@ -29,7 +29,7 @@ const WIN_RECT coords [4][3] = {
 	}
 };
 
-WINDOW *get_window (struct tile_state *ts, unsigned short row, unsigned short col) {
+static WINDOW *get_window (struct tile_state *ts, unsigned short row, unsigned short col) {
 	if (!ts->active [row][col]) {
 		if (WinOpen (&ts->windows [row][col], &coords [row][col], WF_SAVE_SCR)) {
 			ts->active [row][col] = 1;
@@ -40,7 +40,7 @@ WINDOW *get_window (struct tile_state *ts, unsigned short row, unsigned short co
 	return &ts->windows [row][col];
 }
 
-int draw_tile (struct tile_state *ts, unsigned short row, unsigned short col, const char *code, const char *label, int large) {
+static int draw_tile (struct tile_state *ts, unsigned short row, unsigned short col, const char *code, const char *label, int large) {
 	WINDOW *w = get_window (ts, row, col);
 	WinActivate (w);
 	WinClr (w);
@@ -49,21 +49,21 @@ int draw_tile (struct tile_state *ts, unsigned short row, unsigned short col, co
 	if (large)
 		WinFont (w, F_8x10);
 	else
-		WinFont (w, F_6x8);	
+		WinFont (w, F_6x8);
 	WinStrXY (w, 2, 1, code);
 	WinFont (w, F_4x6);
 	WinStrXY (w, 2, 11, label);
 	return 1;
 }
 
-void close_tile (struct tile_state *ts, unsigned short row, unsigned short col) {
+static void close_tile (struct tile_state *ts, unsigned short row, unsigned short col) {
 	if (ts->active [row][col]) {
 		WinClose (&ts->windows [row][col]);
 		ts->active [row][col] = 0;
 	}
 }
 
-void destruct_tiles (struct tile_state *ts) {
+static void destruct_tiles (struct tile_state *ts) {
 	unsigned short x,y;
 	for (x = 0; x < 4; x++)
 	for (y = 0; y < 3; y++)

--- a/gfx/tile.h
+++ b/gfx/tile.h
@@ -7,8 +7,4 @@ struct tile_state {
 	WINDOW windows [4][3];
 };
 
-int draw_tile (struct tile_state *ts, unsigned short row, unsigned short col, const char *code, const char *label, int large);
-void close_tile (struct tile_state *ts, unsigned short row, unsigned short col);
-void destruct_tiles (struct tile_state *ts);
-
 #endif

--- a/mainmenu/main_menu.h
+++ b/mainmenu/main_menu.h
@@ -20,23 +20,4 @@ struct menu_state {
 	struct tile_state ts;
 };
 
-/* If any of these functions return zero, the menu_state struct 
- * can be considered in a broken state.
- * must call clear state immediately and exit the program
- */
-
-
-/* resets the menu state to the position putting the cursor at the top left and the position at top 
- * returns 0 on failure, 1 on success, 2 if no codes are in the manifest.
- */
-int reset_at_position (struct menu_state *ms, unsigned short top);
-unsigned short position (struct menu_state *ms);
-/* frees the memory in the menu state. unlocks all locked files */
-void clear_state (struct menu_state *ms);
-/* updates all codes that need upated */
-int update_codes (struct menu_state *ms, int64_t current_time, int force_draw);
-int move_cursor_left (struct menu_state *ms);
-int move_cursor_right (struct menu_state *ms);
-int move_cursor_up (struct menu_state *ms);
-int move_cursor_down (struct menu_state *ms);
 #endif

--- a/save/manifest.c
+++ b/save/manifest.c
@@ -10,7 +10,17 @@ char *MANIFEST_FILE_P = MANIFEST_FILE + sizeof (MANIFEST_FILE) - 1;
 char MANIFEST_TYPE_TAG [] = {0, 'M', 'A', 'N', 'F', 0, OTH_TAG};
 char MANIFEST_HEAD [] = {'M', 'A', 'N', 'F'};
 
-HANDLE init_manifest (int *error_code) {
+/* call create_directory of util.h before calling any of these
+ * below functions
+ */
+
+/* loads the manifest file, creates if it does not already exists
+ * returns the handle to the file or H_NULL if unsuccessful
+ * 
+ * this does not guarantee that the files listed in the manifest
+ * actually exist or are valid
+ */
+static HANDLE init_manifest (int *error_code) {
 	HSym hs = SymFind (MANIFEST_FILE_P);
 	if (hs.folder == 0) {
 		/* the file does not exists. must now create it */
@@ -126,7 +136,10 @@ HANDLE init_manifest (int *error_code) {
 	}
 }
 
-int set_time_zone (HANDLE manifest_handle, short tz) {
+/* tz is the timezone utc offset expressed in minutes 
+ * returns one of the error codes
+ */
+static int set_time_zone (HANDLE manifest_handle, short tz) {
 	MULTI_EXPR *calc_var = HeapDeref (manifest_handle);
 	if (calc_var == NULL)
 		return MANIFEST_OTHER_ERROR;
@@ -134,7 +147,9 @@ int set_time_zone (HANDLE manifest_handle, short tz) {
 	return MANIFEST_OK;
 }
 
-int get_time_zone (HANDLE manifest_handle, short *tz) {
+/* like set_time_zone. tz will be filled with the current time zone
+ */
+static int get_time_zone (HANDLE manifest_handle, short *tz) {
 	MULTI_EXPR *calc_var = HeapDeref (manifest_handle);
 	if (calc_var == NULL)
 		return MANIFEST_OTHER_ERROR;
@@ -142,7 +157,8 @@ int get_time_zone (HANDLE manifest_handle, short *tz) {
 	return MANIFEST_OK;
 }
 
-int set_position (HANDLE manifest_handle, unsigned short pos) {
+/* these are just like set_time_zone and get_time_zone respectively */
+static int set_position (HANDLE manifest_handle, unsigned short pos) {
 	MULTI_EXPR *calc_var = HeapDeref (manifest_handle);
 	if (calc_var == NULL)
 		return MANIFEST_OTHER_ERROR;
@@ -150,7 +166,7 @@ int set_position (HANDLE manifest_handle, unsigned short pos) {
 	return MANIFEST_OK;
 }
 
-int get_position (HANDLE manifest_handle, unsigned short *pos) {
+static int get_position (HANDLE manifest_handle, unsigned short *pos) {
 	MULTI_EXPR *calc_var = HeapDeref (manifest_handle);
 	if (calc_var == NULL)
 		return MANIFEST_OTHER_ERROR;
@@ -158,7 +174,8 @@ int get_position (HANDLE manifest_handle, unsigned short *pos) {
 	return MANIFEST_OK;
 }
 
-int add_file (HANDLE manifest_handle, char *file_name) {
+/* adds a filename onto the end of the manifest file */
+static int add_file (HANDLE manifest_handle, char *file_name) {
 	MULTI_EXPR *calc_var = HeapDeref (manifest_handle);
 	if (calc_var == NULL)
 		return MANIFEST_OTHER_ERROR;
@@ -192,7 +209,11 @@ int add_file (HANDLE manifest_handle, char *file_name) {
 	return MANIFEST_OK;	
 }
 
-int get_file (HANDLE manifest_handle, char *file_name, unsigned short index) {
+/* gets a file name from the manifest file 
+ * file name points to a buffer that is at least nine bytes long.
+ * will write the name of the file to it, adding zero terminator.
+ */
+static int get_file (HANDLE manifest_handle, char *file_name, unsigned short index) {
 	MULTI_EXPR *calc_var = HeapDeref (manifest_handle);
 	if (calc_var == NULL)
 		return MANIFEST_OTHER_ERROR;
@@ -205,7 +226,7 @@ int get_file (HANDLE manifest_handle, char *file_name, unsigned short index) {
 	return MANIFEST_OK;
 }
 
-int remove_file (HANDLE manifest_handle, unsigned short index) {
+static int remove_file (HANDLE manifest_handle, unsigned short index) {
 	MULTI_EXPR *calc_var = HeapDeref (manifest_handle);
 	if (calc_var == NULL)
 		return MANIFEST_OTHER_ERROR;
@@ -225,7 +246,8 @@ int remove_file (HANDLE manifest_handle, unsigned short index) {
 	return MANIFEST_OK;
 }
 
-int swap_positions (HANDLE manifest_handle, unsigned short pos1, unsigned short pos2) {
+/* swaps the positions of one file with another in the manifest */
+static int swap_positions (HANDLE manifest_handle, unsigned short pos1, unsigned short pos2) {
 	char tmp [8];
 	MULTI_EXPR *calc_var = HeapDeref (manifest_handle);
 	if (calc_var == NULL)
@@ -239,7 +261,7 @@ int swap_positions (HANDLE manifest_handle, unsigned short pos1, unsigned short 
 	return MANIFEST_OK;
 }
 
-unsigned short get_size (HANDLE manifest_handle) {
+static unsigned short get_size (HANDLE manifest_handle) {
 	MULTI_EXPR *calc_var = HeapDeref (manifest_handle);
 	if (calc_var == NULL)
 		return 0;

--- a/save/manifest.h
+++ b/save/manifest.h
@@ -17,38 +17,4 @@
 
 #include <alloc.h>
 
-/* call create_directory of util.h before calling any of these
- * below functions
- */
-
-/* loads the manifest file, creates if it does not already exists
- * returns the handle to the file or H_NULL if unsuccessful
- * 
- * this does not guarantee that the files listed in the manifest
- * actually exist or are valid
- */
-HANDLE init_manifest (int *error_code);
-/* tz is the timezone utc offset expressed in minutes 
- * returns one of the error codes
- */
-int set_time_zone (HANDLE manifest_handle, short tz);
-/* like set_time_zone. tz will be filled with the current time zone
- */
-int get_time_zone (HANDLE manifest_handle, short *tz);
-
-/* these are just like set_time_zone and get_time_zone respectively */
-int get_position (HANDLE manifest_handle, unsigned short *pos);
-int set_position (HANDLE manifest_handle, unsigned short pos);
-
-/* adds a filename onto the end of the manifest file */
-int add_file (HANDLE manifest_handle, char *file_name);
-int remove_file (HANDLE manifest_handle, unsigned short index);
-/* gets a file name from the manifest file 
- * file name points to a buffer that is at least nine bytes long.
- * will write the name of the file to it, adding zero terminator.
- */
-int get_file (HANDLE manifest_handle, char *file_name, unsigned short index);
-/* swaps the positions of one file with another in the manifest */
-int swap_positions (HANDLE manifest_handle, unsigned short pos1, unsigned short pos2);
-unsigned short get_size (HANDLE manifest_handle);
 #endif

--- a/save/secret_file.c
+++ b/save/secret_file.c
@@ -4,13 +4,13 @@
 #include <vat.h>
 
 #include "secret_file.h"
-#include "util.h"
+#include "util.c"
 
 const char FILE_TYPE_TAG [] = {0, 'S', 'E', 'C', 'R', 0, OTH_TAG};
 const char secrets_path [] = "secrets\\";
 const char SPECIAL_RESERVED_NAME [] = "manifest";
 
-int is_valid_name (char *name) {
+static int is_valid_name (char *name) {
 	unsigned short i;
 	for (i = 0; i < 8; i++) {
 		if (name [i] == '\0')
@@ -21,7 +21,21 @@ int is_valid_name (char *name) {
 	return 0;
 }
 
-int write_secret (struct loaded_secret *sec, char *secret_file_name) {
+/* These function take the secret file name as an zero terminated
+ * ASCII string and a pointer to a loaded_secret.
+ * they could return any one of the return codes defined in util.h */
+
+/* before calling either of these functions, make sure to call
+ * create_directory of util.h and that it is successful */
+
+/* Just so you know, accessing files on the calculator's file system
+ * is a highly bizarre process consisting of many steps,
+ * involving many system calls, of which some are buggy, and if one
+ * gets a single step wrong, they risk crashing the entire os. This
+ * crash could happen even after the user program terminates.
+ * It took many long hours to debug just these two functions */
+
+static int write_secret (struct loaded_secret *sec, char *secret_file_name) {
 	char file_name_buffer [9];
 	char *file_sym_str_p = convert_to_sym_str (file_name_buffer, secret_file_name);
 	/* check for reserved names */
@@ -97,10 +111,9 @@ int write_secret (struct loaded_secret *sec, char *secret_file_name) {
 	error_with_memory_allocated:
 	HeapFree (h);
 	return SECRET_OTHER_ERROR;
-	
 }
 
-int read_secret (struct loaded_secret *sec, char *secret_file_name) {
+static int read_secret (struct loaded_secret *sec, char *secret_file_name) {
 	char file_name_buffer [9], full_path_buffer [20], full_path [20];
 	char *file_sym_str_p = convert_to_sym_str (file_name_buffer, secret_file_name);
 	/* check for reserved names */
@@ -165,5 +178,4 @@ int read_secret (struct loaded_secret *sec, char *secret_file_name) {
 		return SECRET_FILE_INVALID;
 	sec->file_handle = se->handle;
 	return SECRET_OK;
-	
 }

--- a/save/secret_file.h
+++ b/save/secret_file.h
@@ -26,21 +26,4 @@ struct loaded_secret {
 };
 
 
-/* These function take the secret file name as an zero terminated
- * ASCII string and a pointer to a loaded_secret.
- * they could return any one of the return codes defined in util.h*/
- 
-/* before calling either of these functions, make sure to call
- * create_directory of util.h and that it is successful */
-
-int write_secret (struct loaded_secret *sec, char *secret_file_name);
-int read_secret (struct loaded_secret *sec, char *secret_file_name);
-
 #endif
-
-/* Just so you know, accessing files on the calculator's file system
- * is a highly bizarre process consisting of many steps,
- * involving many system calls, of which some are buggy, and if one
- * gets a single step wrong, they risk crashing the entire os. This
- * crash could happen even after the user program terminates.
- * It took many long hours to debug just these two functions */

--- a/save/util.c
+++ b/save/util.c
@@ -5,7 +5,15 @@
 const char DEFAULT_DIRECTORY [] = "\0secrets";
 const char *DEFAULT_DIRECTORY_P = DEFAULT_DIRECTORY + sizeof(DEFAULT_DIRECTORY) - 1;
 
-char *convert_to_sym_str (char *buf, char *src) {
+/* Convert a zero terminated ASCII string into the ridiculous format
+ * that the calculator insists on for its VAT handling functions.
+ * pass into src the NULL terminated string of at most 8 characters
+ * pass into buf, a buffer of 9 characters. this will not be passed
+ * into any files, but it will be used as the storage space that backs
+ * the pointer.
+ * it returns the pointer that you should give to the VAT functions
+ */
+static char *convert_to_sym_str (char *buf, char *src) {
 	char *dst = buf;
 	*dst = '\0';
 	dst += 1;
@@ -18,7 +26,15 @@ char *convert_to_sym_str (char *buf, char *src) {
 	return dst;
 }
 
-int create_directory () {
+/*
+ * This macro is intended to be used for constant zero terminated 
+ * strings that already begin with a null terminating byte.
+ */
+
+/* creates the secrets directory, if it does not exist
+ * returns SECRET_OK normally, or with some other return
+ * code from the above if not successful. */
+static int create_directory () {
 	short s = FolderFind (DEFAULT_DIRECTORY_P);
 	if (s == NOT_FOUND) {
 		HANDLE hh = FolderAdd (DEFAULT_DIRECTORY_P);

--- a/save/util.h
+++ b/save/util.h
@@ -13,24 +13,4 @@
 /* the name of the default directory */
 const char *DEFAULT_DIRECTORY_P;
 
-/* Convert a zero terminated ASCII string into the ridiculous format
- * that the calculator insists on for its VAT handling functions.
- * pass into src the NULL terminated string of at most 8 characters
- * pass into buf, a buffer of 9 characters. this will not be passed
- * into any files, but it will be used as the storage space that backs
- * the pointer.
- * it returns the pointer that you should give to the VAT functions
- */
-char *convert_to_sym_str (char *buf, char *src);
-
-/*
- * This macro is intended to be used for constant zero terminated 
- * strings that already begin with a null terminating byte.
- */
-
-/* creates the secrets directory, if it does not exist
- * returns SECRET_OK normally, or with some other return
- * code from the above if not successful. */
-int create_directory ();
-
 #endif

--- a/time/time.c
+++ b/time/time.c
@@ -5,8 +5,8 @@
 #include <statline.h>
 #include <unknown.h>
 
-const char *DOW [7] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-const char *MOY [12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+const char DOW [7][4] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+const char MOY [12][4] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
 int64_t get_timestamp (int set_stat, short time_zone) {
 	unsigned short year, month, day, hour, minute, second;

--- a/time/time.c
+++ b/time/time.c
@@ -8,22 +8,13 @@
 const char DOW [7][4] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 const char MOY [12][4] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
-int64_t get_timestamp (int set_stat, short time_zone) {
-	unsigned short year, month, day, hour, minute, second;
-	char statline_string [60];
-	DateAndTime_Get (&year, &month, &day, &hour, &minute, &second);
-	int64_t current_time = timestamp_from_civil (year, month, day, hour, minute, second);
-	current_time -= time_zone * 60;
-	
-	if (set_stat) {
-		unsigned short dow = DayOfTheWeek (year, month, day);
-		sprintf(statline_string, "%02d %s %04d %s %02d:%02d:%02d", day, MOY [month - 1], year, DOW [dow - 1], hour, minute, second);
-		ST_helpMsg (statline_string);
-	}
-	return current_time;
-}
-
-int64_t timestamp_from_civil (unsigned short year, unsigned short month, unsigned short day, unsigned short hour, unsigned short minute, unsigned short second) {
+/*
+ * TOTP very reasonably uses unix time,
+ * but the calcualtors regretably have no concept of this.
+ * They only have this system call called DateAndTime_Get
+ * which gives calendar days.
+ */
+static int64_t timestamp_from_civil (unsigned short year, unsigned short month, unsigned short day, unsigned short hour, unsigned short minute, unsigned short second) {
 	year -= month <= 2;
 	const int32_t era = (year >= 0 ? year : year - 399) / 400;
 	uint64_t yoe = (uint32_t)(year - era * 400);
@@ -32,4 +23,25 @@ int64_t timestamp_from_civil (unsigned short year, unsigned short month, unsigne
 	int64_t total_days = era * 146097 + (int64_t)(doe) - 719468;
 
 	return total_days * 86400 + ((int64_t) hour) * 3600 + ((int64_t) minute) * 60 + (int64_t) second;
+}
+
+/* The calculator also has no concept of time-zones.
+ * users can be expected to set the clock on their calcualtor
+ * to their local time while the unix epoch and therefore TOTP
+ * will be in UTC. You must do a conversion sometime before
+ * calculating the TOTP period.
+ */
+static int64_t get_timestamp (int set_stat, short time_zone) {
+	unsigned short year, month, day, hour, minute, second;
+	char statline_string [60];
+	DateAndTime_Get (&year, &month, &day, &hour, &minute, &second);
+	int64_t current_time = timestamp_from_civil (year, month, day, hour, minute, second);
+	current_time -= time_zone * 60;
+
+	if (set_stat) {
+		unsigned short dow = DayOfTheWeek (year, month, day);
+		sprintf(statline_string, "%02d %s %04d %s %02d:%02d:%02d", day, MOY [month - 1], year, DOW [dow - 1], hour, minute, second);
+		ST_helpMsg (statline_string);
+	}
+	return current_time;
 }

--- a/time/time.h
+++ b/time/time.h
@@ -3,28 +3,5 @@
 
 #include <inttypes.h>
 
-/*
- * TOTP very reasonably uses unix time,
- * but the calcualtors regretably have no concept of this.
- * They only have this system call called DateAndTime_Get
- * which gives calendar days.
- */
-int64_t timestamp_from_civil (
-	unsigned short year,
-	unsigned short month,
-	unsigned short day,
-	unsigned short hour,
-	unsigned short minute,
-	unsigned short second
-);
-
-int64_t get_timestamp (int set_stat, short time_zone);
-
 #endif
 
-/* The calculator also has no concept of time-zones.
- * users can be expected to set the clock on their calcualtor
- * to their local time while the unix epoch and therefore TOTP
- * will be in UTC. You must do a conversion sometime before
- * calculating the TOTP period.
- */

--- a/time/time.h
+++ b/time/time.h
@@ -1,8 +1,6 @@
 #ifndef TIME_H
 #define TIME_H
 
-#define MIN_AMS 207
-
 #include <inttypes.h>
 
 /*

--- a/totp.c
+++ b/totp.c
@@ -7,19 +7,23 @@
 
 #include <tigcclib.h>
 
-#include "save/util.h"
-#include "save/manifest.h"
-#include "mainmenu/main_menu.h"
-#include "dialog/time_zone.h"
-#include "dialog/new_secret.h"
-#include "time/time.h"
+#include "codes/hash/sha1/sha1/sha1.c"
+#include "codes/hmac/hmac.c"
+#include "codes/hotp/hotp.c"
+#include "time/time.c"
+#include "gfx/tile.c"
+#include "save/secret_file.c"
+//#include "save/util.c"
+#include "save/manifest.c"
+#include "dialog/new_secret.c"
+#include "dialog/time_zone.c"
+#include "mainmenu/main_menu.c"
 
 #include "bin/commit_hash.h"
 
-const char ERROR_MEM [] = "You may not have enough memory.";
 const char NO_SECRETS [] = "No secrets.";
 
-int guarantee_at_least_one_secret (HANDLE manifest_file, int wide_format) {
+static int guarantee_at_least_one_secret (HANDLE manifest_file, int wide_format) {
 	/* special case: user has no secrets loaded. this happens always on first run 
 	 * it can also happen on deletion
 	 */


### PR DESCRIPTION
I spent a bit of time reducing the size of your program, yielding a ~3 KB size reduction :)
From an optimization POV, your code isn't intrinsically bad. Most of the size decrease comes from the usage of optimized toolchain flags: the default toolchain flags aim at compatibility with just about any code style and maximal OS version support, at the expense of size and/or speed optimization, whereas the set of optimized build flags I cooked up by trial-error works well for reducing the size of this program but isn't applicable to some other programs verbatim: build errors, worse optimization, incorrect code generation can ensue.
Additionally, this program is made up of functions which have few call sites, often a single one; the usage of multiple small files compiled separately and linked together prevents inlining and subsequent optimizations from kicking in. On modern toolchains, LTO could perform these optimizations; on old toolchains such as GCC4TI's, it's easy enough to emulate it manually by #include'ing C files and marking functions static.

Note that I didn't _thoroughly_ check the functionality of the program after my changes. I mean, I checked that it produces some 6-digit codes which change every 30 seconds, and that the emulated calculator didn't crash, but I didn't check that the TOTP codes are actually correct :)